### PR TITLE
fix: Correct TypeScript types path in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Superfast React Native bindings for LevelDB",
   "main": "lib/commonjs/index",
   "module": "lib/module/index",
-  "types": "lib/typescript/src/index.d.ts",
+  "types": "lib/typescript/index.d.ts",
   "react-native": "src/index",
   "source": "src/index",
   "files": [


### PR DESCRIPTION
Heya, I'm finally getting the chance to try this out - the TypeScript definitions don't point to the correct path, which causes TypeScript to refuse to import the module.

You can verify this by downloading `react-native-leveldb@1.0.5` from npm, the TypeScript definition file is in `lib/typescript/index.d.ts`, not `lib/typescript/src/index.d.ts`.

This path seems to come from here, which I assume is wrong:

https://github.com/callstack/react-native-builder-bob/blob/main/src/cli.ts#L157