### PR TITLE
chore: Android: skip unnecessary build steps

### DIFF
--- a/android/CMakeLists.txt
+++ b/android/CMakeLists.txt
@@ -7,6 +7,10 @@ set (CMAKE_VERBOSE_MAKEFILE ON)
 set (CMAKE_CXX_STANDARD 14)
 set (BUILD_DIR ${CMAKE_SOURCE_DIR}/build)
 
+set (LEVELDB_BUILD_TESTS OFF)
+set (LEVELDB_BUILD_BENCHMARKS OFF)
+set (LEVELDB_INSTALL OFF)
+
 add_subdirectory(../cpp/leveldb
         ./leveldb
         EXCLUDE_FROM_ALL)


### PR DESCRIPTION
No need to build tests, benchmarks, or install the library.

iOS already builds without CMake
This sets the CMake options to not build unnecessary things and seems to speed up the build. I'm not a CMake expert so might not have done it the right way but it seems correct.