### PR TITLE
feat: added compareKey(target)

### DIFF
--- a/cpp/react-native-leveldb.cpp
+++ b/cpp/react-native-leveldb.cpp
@@ -327,6 +327,27 @@ void installLeveldb(jsi::Runtime& jsiRuntime, std::string documentDir) {
       }
   );
   jsiRuntime.global().setProperty(jsiRuntime, "leveldbIteratorKeyStr", std::move(leveldbIteratorKeyStr));
+  
+  auto leveldbIteratorKeyCompare = jsi::Function::createFromHostFunction
+  (
+   jsiRuntime,
+   jsi::PropNameID::forAscii(jsiRuntime, "leveldbIteratorKeyCompare"),
+   2,  // iterators index, comparison target
+   [](jsi::Runtime& runtime, const jsi::Value& thisValue, const jsi::Value* arguments, size_t count) -> jsi::Value {
+     leveldb::Iterator* iterator = valueToIterator(arguments[0]);
+     std::string target;
+     if (!valueToString(runtime, arguments[1], &target)) {
+       throw jsi::JSError(runtime, "leveldbIteratorKeyCompare/invalid-params");
+     }
+     // Compare with input comparison string
+     int comparisonResult = iterator->key().compare(target);
+     if (!iterator) {
+       throw jsi::JSError(runtime, "leveldbIteratorKeyCompare/invalid-params");
+     }
+     return jsi::Value(comparisonResult);
+   }
+   );
+  jsiRuntime.global().setProperty(jsiRuntime, "leveldbIteratorKeyCompare", std::move(leveldbIteratorKeyCompare));
 
   auto leveldbIteratorValueStr = jsi::Function::createFromHostFunction(
       jsiRuntime,

--- a/example/ios/LeveldbExample.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/example/ios/LeveldbExample.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEDidComputeMac32BitWarning</key>
+	<true/>
+</dict>
+</plist>

--- a/example/ios/LeveldbExample.xcworkspace/xcshareddata/WorkspaceSettings.xcsettings
+++ b/example/ios/LeveldbExample.xcworkspace/xcshareddata/WorkspaceSettings.xcsettings
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>PreviewsEnabled</key>
+	<false/>
+</dict>
+</plist>

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -300,7 +300,7 @@ PODS:
   - React-jsinspector (0.68.2)
   - React-logger (0.68.2):
     - glog
-  - react-native-leveldb (3.0.4):
+  - react-native-leveldb (3.0.6):
     - React-Core
   - React-perflogger (0.68.2)
   - React-RCTActionSheet (0.68.2):
@@ -541,11 +541,11 @@ SPEC CHECKSUMS:
   Flipper-RSocket: d9d9ade67cbecf6ac10730304bf5607266dd2541
   FlipperKit: cbdee19bdd4e7f05472a66ce290f1b729ba3cb86
   fmt: ff9d55029c625d3757ed641535fd4a75fedc7ce9
-  glog: 5337263514dd6f09803962437687240c5dc39aa4
+  glog: 476ee3e89abb49e07f822b48323c51c57124b572
   hermes-engine: 84e3af1ea01dd7351ac5d8689cbbea1f9903ffc3
   libevent: 4049cae6c81cdb3654a443be001fb9bdceff7913
   OpenSSL-Universal: ebc357f1e6bc71fa463ccb2fe676756aff50e88c
-  RCT-Folly: a21c126816d8025b547704b777a2ba552f3d9fa9
+  RCT-Folly: 4d8508a426467c48885f1151029bc15fa5d7b3b8
   RCTRequired: 3e917ea5377751094f38145fdece525aa90545a0
   RCTTypeSafety: c43c072a4bd60feb49a9570b0517892b4305c45e
   React: 176dd882de001854ced260fad41bb68a31aa4bd0
@@ -559,7 +559,7 @@ SPEC CHECKSUMS:
   React-jsiexecutor: b7b553412f2ec768fe6c8f27cd6bafdb9d8719e6
   React-jsinspector: c5989c77cb89ae6a69561095a61cce56a44ae8e8
   React-logger: a0833912d93b36b791b7a521672d8ee89107aff1
-  react-native-leveldb: 628ce07a47bf8a670d6ba09cf64f8d17ecd930e2
+  react-native-leveldb: d36cf53daa1715f090a62a5b2a44fb23b1066d3f
   React-perflogger: a18b4f0bd933b8b24ecf9f3c54f9bf65180f3fe6
   React-RCTActionSheet: 547fe42fdb4b6089598d79f8e1d855d7c23e2162
   React-RCTAnimation: bc9440a1c37b06ae9ebbb532d244f607805c6034
@@ -579,4 +579,4 @@ SPEC CHECKSUMS:
 
 PODFILE CHECKSUM: 6eab7d9bf7af7623131527fa29d5f91eb48fd42f
 
-COCOAPODS: 1.11.2
+COCOAPODS: 1.11.3

--- a/example/src/benchmark.tsx
+++ b/example/src/benchmark.tsx
@@ -44,7 +44,7 @@ export async function benchmarkAsyncStorage(): Promise<BenchmarkResults> {
   console.info('Clearing AsyncStorage');
   try {
     await AsyncStorage.clear();
-  } catch (e) {
+  } catch (e: any) {
     if (!e?.message?.includes('Failed to delete storage directory')) {
       throw e;
     }

--- a/package.json
+++ b/package.json
@@ -70,7 +70,8 @@
     "react-native": "0.68.2",
     "react-native-builder-bob": "^0.18.2",
     "release-it": "^15.0.0",
-    "typescript": "^4.5.2"
+    "typescript": "^4.5.2",
+    "metro-react-native-babel-preset": "^0.67.0"
   },
   "resolutions": {
     "@types/react": "17.0.21"

--- a/src/index.ts
+++ b/src/index.ts
@@ -59,6 +59,12 @@ export interface LevelDBIteratorI {
   // REQUIRES: Valid()
   valueStr(): string;
   valueBuf(): ArrayBuffer;
+
+  /**
+   * Executes a comparison using the underlying iterator's Compare(Slice ...) method
+   * @param target 
+   */
+  compareKey(target: ArrayBuffer | string): number;
 }
 
 export interface LevelDBI {
@@ -144,6 +150,9 @@ export class LevelDBIterator implements LevelDBIteratorI {
 
   valueBuf(): ArrayBuffer {
     return g.leveldbIteratorValueBuf(this.ref);
+  }
+  compareKey(target: ArrayBuffer | string) : number {
+    return g.leveldbIteratorKeyCompare(this.ref, target);
   }
 }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -7846,7 +7846,7 @@ metro-minify-uglify@0.67.0:
   dependencies:
     uglify-es "^3.1.9"
 
-metro-react-native-babel-preset@0.67.0:
+metro-react-native-babel-preset@0.67.0, metro-react-native-babel-preset@^0.67.0:
   version "0.67.0"
   resolved "https://registry.yarnpkg.com/metro-react-native-babel-preset/-/metro-react-native-babel-preset-0.67.0.tgz#53aec093f53a09b56236a9bb534d76658efcbec7"
   integrity sha512-tgTG4j0SKwLHbLRELMmgkgkjV1biYkWlGGKOmM484/fJC6bpDikdaFhfjsyE+W+qt7I5szbCPCickMTNQ+zwig==


### PR DESCRIPTION
Added `compareKey` to the iterator so it's possible to compare the current key of the iterator to a string/ArrayBuffer using the underlying `Compare()` method.

I'm trying to implement a `abstract-level` compliant wrapper around this library and found that this should help with the implementation of a `gt`, `gte`, `lt`, `lte` requirements for the iterator.