### PR TITLE
feat: added namespace for AGP 8 support

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -49,7 +49,7 @@ android {
   compileSdkVersion safeExtGet('compileSdkVersion', 28)
   def agpVersion = com.android.Version.ANDROID_GRADLE_PLUGIN_VERSION
   if (agpVersion.tokenize('.')[0].toInteger() >= 7) {
-    namespace "com.shopify.reactnative.skia"
+    namespace "com.reactnativeleveldb"
   }
   
   // Used to override the NDK path/version on internal CI or by allowing

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -49,7 +49,10 @@ android {
   compileSdkVersion safeExtGet('compileSdkVersion', 28)
   def agpVersion = com.android.Version.ANDROID_GRADLE_PLUGIN_VERSION
   if (agpVersion.tokenize('.')[0].toInteger() >= 7) {
-    namespace "com.reactnativeleveldb"
+    namespace "com.reactnativecommunity.asyncstorage"
+    buildFeatures {
+      buildConfig true
+    }
   }
   
   // Used to override the NDK path/version on internal CI or by allowing

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -47,7 +47,11 @@ repositories {
 
 android {
   compileSdkVersion safeExtGet('compileSdkVersion', 28)
-
+  def agpVersion = com.android.Version.ANDROID_GRADLE_PLUGIN_VERSION
+  if (agpVersion.tokenize('.')[0].toInteger() >= 7) {
+    namespace "com.shopify.reactnative.skia"
+  }
+  
   // Used to override the NDK path/version on internal CI or by allowing
   // users to customize the NDK path/version from their root project (e.g. for M1 support)
   if (rootProject.hasProperty('ndkPath')) {

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -49,7 +49,7 @@ android {
   compileSdkVersion safeExtGet('compileSdkVersion', 28)
   def agpVersion = com.android.Version.ANDROID_GRADLE_PLUGIN_VERSION
   if (agpVersion.tokenize('.')[0].toInteger() >= 7) {
-    namespace "com.reactnativecommunity.asyncstorage"
+    namespace "com.reactnativeleveldb"
     buildFeatures {
       buildConfig true
     }


### PR DESCRIPTION
This was done to support Android for `react-native v0.73.0`, Upcoming 0.73.0 has a breaking change for android due to AGP


* [Android] Bump to AGP 8.0 https://github.com/react-native-community/discussions-and-proposals/issues/
  *  breaking changes for libraries -> https://developer.android.com/build/releases/gradle-plugin#namespace-dsl
  * https://github.com/facebook/react-native/pull/37019
    example: https://github.com/expo/expo/pull/22609/files#diff-ef1f15fe3a85e91b5b14cecbe065dd88e055f86f9b54c66fbdfd2c40ce95aa4b

see: https://github.com/reactwg/react-native-releases/discussions/64 for more info

---
fixes #24 